### PR TITLE
Added ability to set 'app' and 'private_instance_id' for registration

### DIFF
--- a/heartbeater_test.go
+++ b/heartbeater_test.go
@@ -26,6 +26,8 @@ var _ = Describe("Heartbeater", func() {
 		URIs: []string{"foo.bar.com", "example.com"},
 		Host: "1.2.3.4",
 		Port: 4567,
+		App: "my-awesome-app",
+		PrivateInstanceId: "deadbeef-c0ffee",
 	}
 
 	BeforeEach(func() {

--- a/nats_info.go
+++ b/nats_info.go
@@ -14,9 +14,11 @@ const (
 )
 
 type RegistryMessage struct {
-	URIs []string `json:"uris"`
-	Host string   `json:"host"`
-	Port int      `json:"port"`
+	URIs []string            `json:"uris"`
+	Host string              `json:"host"`
+	Port int                 `json:"port"`
+	App string               `json:"app"`
+	PrivateInstanceId string `json:"private_instance_id"`
 }
 
 type GreetingMessage struct {


### PR DESCRIPTION
For a HA backend service (such as a dashboard) I need to have requests be sticky. To enable this I need to set the `private_instance_id` in the RegistryMessage so that the gorouter does the right thing by setting a `__VCAP_ID__` cookie. This is enabled by a `private_instance_id` in the registration message.
